### PR TITLE
[feat] Mailer

### DIFF
--- a/Constants/MailTemplates.cs
+++ b/Constants/MailTemplates.cs
@@ -1,0 +1,6 @@
+public static class MailTemplates {
+    public const string PATH = "Templates/Mail/";
+
+
+    public const string TEST = PATH + "TestMailTemplate.html";
+}

--- a/Controllers/GameController.cs
+++ b/Controllers/GameController.cs
@@ -12,8 +12,7 @@ namespace GamesAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]s")]
-public class GameController : ControllerBase
-{
+public class GameController : ControllerBase {
     private readonly IMapper _mapper;
     private readonly IGameService _gameService;
     private readonly IFileService _fileService;

--- a/Controllers/TestController.cs
+++ b/Controllers/TestController.cs
@@ -24,8 +24,8 @@ public class TestController : ControllerBase {
             Ccs = new List<MailRecipientData>(),
             Bccs = new List<MailRecipientData>()
         };
-        MailData mailData = new MailData(header, "Subject", "This is a test mail", new MimeKit.BodyBuilder());
-
+        MailData mailData = new MailData(header, "Subject", "This is a test mail");
+        
         return await _mailService.Send(mailData);
     }
 
@@ -40,6 +40,23 @@ public class TestController : ControllerBase {
             Bccs = new List<MailRecipientData>()
         };
         HTMLMailData mailData = new TestHTMLMailData(header);
+
+        return await _mailService.Send(mailData);
+    }
+
+
+    [HttpPost]
+    [Route("attachments-html-mail/send")]
+    public async Task<bool> SendAttachmentsHtmlMail() {
+        MailHeader header = new MailHeader {
+            Recipients = new List<MailRecipientData>() {
+                new MailRecipientData("test@test.com", "Test Emailed")
+            },
+            Ccs = new List<MailRecipientData>(),
+            Bccs = new List<MailRecipientData>()
+        };
+        HTMLMailData mailData = new TestHTMLMailData(header);
+        mailData.AddAttachmentFromPath(Directory.GetCurrentDirectory() + "\\Controllers\\TestController.cs");
 
         return await _mailService.Send(mailData);
     }

--- a/Controllers/TestController.cs
+++ b/Controllers/TestController.cs
@@ -18,11 +18,11 @@ public class TestController : ControllerBase {
     [Route("mail/send")]
     public async Task<bool> SendMail() {
         MailHeader header = new MailHeader {
-            Recipients = new List<MailRecipientData>() {
-                new MailRecipientData("test@test.com", "Test Emailed")
+            Recipients = new List<MailRecipient>() {
+                new MailRecipient("test@test.com", "Test Emailed")
             },
-            Ccs = new List<MailRecipientData>(),
-            Bccs = new List<MailRecipientData>()
+            Ccs = new List<MailRecipient>(),
+            Bccs = new List<MailRecipient>()
         };
         MailData mailData = new MailData(header, "Subject", "This is a test mail");
         
@@ -33,11 +33,11 @@ public class TestController : ControllerBase {
     [Route("html-mail/send")]
     public async Task<bool> SendHtmlMail() {
         MailHeader header = new MailHeader {
-            Recipients = new List<MailRecipientData>() {
-                new MailRecipientData("test@test.com", "Test Emailed")
+            Recipients = new List<MailRecipient>() {
+                new MailRecipient("test@test.com", "Test Emailed")
             },
-            Ccs = new List<MailRecipientData>(),
-            Bccs = new List<MailRecipientData>()
+            Ccs = new List<MailRecipient>(),
+            Bccs = new List<MailRecipient>()
         };
         HTMLMailData mailData = new TestHTMLMailData(header);
 
@@ -49,11 +49,11 @@ public class TestController : ControllerBase {
     [Route("attachments-html-mail/send")]
     public async Task<bool> SendAttachmentsHtmlMail() {
         MailHeader header = new MailHeader {
-            Recipients = new List<MailRecipientData>() {
-                new MailRecipientData("test@test.com", "Test Emailed")
+            Recipients = new List<MailRecipient>() {
+                new MailRecipient("test@test.com", "Test Emailed")
             },
-            Ccs = new List<MailRecipientData>(),
-            Bccs = new List<MailRecipientData>()
+            Ccs = new List<MailRecipient>(),
+            Bccs = new List<MailRecipient>()
         };
         HTMLMailData mailData = new TestHTMLMailData(header);
         mailData.AddAttachmentFromPath(Directory.GetCurrentDirectory() + "\\Controllers\\TestController.cs");

--- a/Controllers/TestController.cs
+++ b/Controllers/TestController.cs
@@ -1,0 +1,47 @@
+using GamesAPI.Core.Models;
+using GamesAPI.Core.Services;
+using Microsoft.AspNetCore.Mvc;
+
+public class TestController : ControllerBase {
+    private readonly IMailService _mailService;
+
+    public TestController(IMailService mailService) {
+        this._mailService = mailService;
+    }
+
+    [HttpGet]
+    public IActionResult Test() {
+        return Ok();
+    }
+
+    [HttpPost]
+    [Route("mail/send")]
+    public async Task<bool> SendMail() {
+        MailHeader header = new MailHeader {
+            Recipients = new List<MailRecipientData>() {
+                new MailRecipientData("test@test.com", "Test Emailed")
+            },
+            Ccs = new List<MailRecipientData>(),
+            Bccs = new List<MailRecipientData>()
+        };
+        MailData mailData = new MailData(header, "Subject", "This is a test mail", new MimeKit.BodyBuilder());
+
+        return await _mailService.Send(mailData);
+    }
+
+    [HttpPost]
+    [Route("html-mail/send")]
+    public async Task<bool> SendHtmlMail() {
+        MailHeader header = new MailHeader {
+            Recipients = new List<MailRecipientData>() {
+                new MailRecipientData("test@test.com", "Test Emailed")
+            },
+            Ccs = new List<MailRecipientData>(),
+            Bccs = new List<MailRecipientData>()
+        };
+        HTMLMailData mailData = new TestHTMLMailData(header);
+
+        return await _mailService.Send(mailData);
+    }
+
+}

--- a/Core/Constants/CoreMailTemplates.cs
+++ b/Core/Constants/CoreMailTemplates.cs
@@ -1,0 +1,6 @@
+public static class CoreMailTemplates {
+    public const string PATH = "Core/Templates/Mail/";
+
+    
+    public const string BASE = PATH + "BaseMailTemplate.html";
+}

--- a/Core/Models/Mail/HTMLMailData.cs
+++ b/Core/Models/Mail/HTMLMailData.cs
@@ -1,0 +1,40 @@
+using MimeKit;
+
+namespace GamesAPI.Core.Models;
+/*
+    Extend this class and override processTemplateParams() to parse custom params
+*/
+public class HTMLMailData : IMailData {
+    public MailHeader Header { get; set; }
+    public string Subject { get; set; } = "";
+    public MimeEntity? Body { get; set; }
+    public string MailPath = CoreMailTemplates.BASE;
+
+    public HTMLMailData(MailHeader header, string subject, MimeEntity body) {
+        this.Header = header;
+        this.Subject = subject;
+        this.Body = body;
+    }
+
+    public HTMLMailData(MailHeader header, string subject, string mailPath = CoreMailTemplates.BASE) {
+        this.Header = header;
+        this.Subject = subject;
+        this.MailPath = mailPath;
+
+        this.BuildBodyFromTemplate(mailPath).Wait();
+    }
+
+    public async Task BuildBodyFromTemplate(string template = CoreMailTemplates.BASE) {
+        string templateBody = await File.ReadAllTextAsync(Path.Combine(Directory.GetCurrentDirectory(), template));
+
+        templateBody = this.processTemplateParams(templateBody);
+
+        this.Body = new TextPart(MimeKit.Text.TextFormat.Html) {
+            Text = templateBody
+        };
+    }
+
+    public virtual string processTemplateParams(string templateBody) {
+        return string.Format(templateBody, "parameter 1, the next one will be today's date", DateTime.Today.Date.ToShortDateString());
+    }
+}

--- a/Core/Models/Mail/HTMLMailData.cs
+++ b/Core/Models/Mail/HTMLMailData.cs
@@ -4,34 +4,21 @@ namespace GamesAPI.Core.Models;
 /*
     Extend this class and override processTemplateParams() to parse custom params
 */
-public class HTMLMailData : IMailData {
-    public MailHeader Header { get; set; }
-    public string Subject { get; set; } = "";
-    public MimeEntity? Body { get; set; }
+public class HTMLMailData : MailData {
     public string MailPath = CoreMailTemplates.BASE;
 
-    public HTMLMailData(MailHeader header, string subject, MimeEntity body) {
-        this.Header = header;
-        this.Subject = subject;
-        this.Body = body;
-    }
+    public HTMLMailData(MailHeader header, string subject, MimeEntity body) : base(header, subject) { }
 
-    public HTMLMailData(MailHeader header, string subject, string mailPath = CoreMailTemplates.BASE) {
-        this.Header = header;
-        this.Subject = subject;
+    public HTMLMailData(MailHeader header, string subject, string mailPath = CoreMailTemplates.BASE): base(header, subject) {
         this.MailPath = mailPath;
 
-        this.BuildBodyFromTemplate(mailPath).Wait();
+        this.AddBodyFromTemplate(mailPath).Wait();
     }
 
-    public async Task BuildBodyFromTemplate(string template = CoreMailTemplates.BASE) {
+    public async Task AddBodyFromTemplate(string template = CoreMailTemplates.BASE) {
         string templateBody = await File.ReadAllTextAsync(Path.Combine(Directory.GetCurrentDirectory(), template));
 
-        templateBody = this.processTemplateParams(templateBody);
-
-        this.Body = new TextPart(MimeKit.Text.TextFormat.Html) {
-            Text = templateBody
-        };
+        this.BodyBuilder.HtmlBody = this.processTemplateParams(templateBody);
     }
 
     public virtual string processTemplateParams(string templateBody) {

--- a/Core/Models/Mail/IMailData.cs
+++ b/Core/Models/Mail/IMailData.cs
@@ -1,0 +1,8 @@
+using GamesAPI.Core.Models;
+using MimeKit;
+
+public interface IMailData {
+    MailHeader Header { get; set; }
+    string Subject { get; set; }
+    MimeEntity? Body { get; set; }
+}

--- a/Core/Models/Mail/IMailData.cs
+++ b/Core/Models/Mail/IMailData.cs
@@ -4,5 +4,9 @@ using MimeKit;
 public interface IMailData {
     MailHeader Header { get; set; }
     string Subject { get; set; }
-    MimeEntity? Body { get; set; }
+    BodyBuilder BodyBuilder { get; set; }
+
+    MailData AddAttachment(MimePart attachment);
+    MailData AddAttachmentFromPath(string filePath);
+    MimeEntity? GetBody();
 }

--- a/Core/Models/Mail/MailData.cs
+++ b/Core/Models/Mail/MailData.cs
@@ -5,30 +5,65 @@ namespace GamesAPI.Core.Models;
 public class MailData: IMailData {
     public MailHeader Header { get; set; }
     public string Subject { get; set; } = "";
-    public MimeEntity? Body { get; set; } = null;
+    public IFormFileCollection Attachments { get; set; } = new FormFileCollection();
+
+
+    public BodyBuilder BodyBuilder { get; set; }
 
     public MailData(MailHeader header, string subject) {
         this.Header = header;
         this.Subject = subject;
+
+        this.BodyBuilder = new BodyBuilder();
     }
 
-    public MailData(MailHeader header, string subject, MimeEntity body) {
+    public MailData(MailHeader header, string subject, BodyBuilder bodyBuilder) {
         this.Header = header;
         this.Subject = subject;
-        this.Body = body;
+        this.BodyBuilder = bodyBuilder;
     }
 
-    public MailData(MailHeader header, string subject, string body, BodyBuilder bodyBuilder) {
+    public MailData(MailHeader header, string subject, string body) {
         this.Header = header;
         this.Subject = subject;
-        this.BodyToMimeEntity(bodyBuilder, body);
+        this.BodyBuilder = new BodyBuilder {
+            TextBody = body
+        };
     }
+    
 
-
-    public MailData BodyToMimeEntity(BodyBuilder bodyBuilder, string body) {
-        bodyBuilder.TextBody = body;
-
-        this.Body = bodyBuilder.ToMessageBody();
+    public MailData AddAttachment(MimePart attachment) {
+        this.BodyBuilder.Attachments.Add(attachment);
         return this;
+    }
+
+    public MailData AddAttachmentFromPath(string filePath) {
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("File not found", filePath);
+
+        byte[] fileBytes = File.ReadAllBytes(filePath);
+
+        MimePart attachment = new MimePart {
+            Content = new MimeContent(new MemoryStream(fileBytes)),
+            ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+            ContentTransferEncoding = ContentEncoding.Base64,
+            FileName = Path.GetFileName(filePath)
+        };
+
+        // using(FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read)) {
+        //     MimePart attachment = new MimePart {
+        //         Content = new MimeContent(fileStream),
+        //         ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
+        //         ContentTransferEncoding = ContentEncoding.Base64,
+        //         FileName = Path.GetFileName(filePath)
+        //     };
+
+        this.AddAttachment(attachment);
+
+        return this;
+    }
+
+    public MimeEntity? GetBody() {
+        return this.BodyBuilder.ToMessageBody();
     }
 }

--- a/Core/Models/Mail/MailData.cs
+++ b/Core/Models/Mail/MailData.cs
@@ -10,17 +10,18 @@ public class MailData: IMailData {
 
     public BodyBuilder BodyBuilder { get; set; }
 
+    // injecting BodyBuilder (by using this constructor) is recommended
+    public MailData(MailHeader header, string subject, BodyBuilder bodyBuilder) {
+        this.Header = header;
+        this.Subject = subject;
+        this.BodyBuilder = bodyBuilder;
+    }
+
     public MailData(MailHeader header, string subject) {
         this.Header = header;
         this.Subject = subject;
 
         this.BodyBuilder = new BodyBuilder();
-    }
-
-    public MailData(MailHeader header, string subject, BodyBuilder bodyBuilder) {
-        this.Header = header;
-        this.Subject = subject;
-        this.BodyBuilder = bodyBuilder;
     }
 
     public MailData(MailHeader header, string subject, string body) {
@@ -49,14 +50,6 @@ public class MailData: IMailData {
             ContentTransferEncoding = ContentEncoding.Base64,
             FileName = Path.GetFileName(filePath)
         };
-
-        // using(FileStream fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read)) {
-        //     MimePart attachment = new MimePart {
-        //         Content = new MimeContent(fileStream),
-        //         ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
-        //         ContentTransferEncoding = ContentEncoding.Base64,
-        //         FileName = Path.GetFileName(filePath)
-        //     };
 
         this.AddAttachment(attachment);
 

--- a/Core/Models/Mail/MailData.cs
+++ b/Core/Models/Mail/MailData.cs
@@ -1,0 +1,34 @@
+using MimeKit;
+
+namespace GamesAPI.Core.Models;
+
+public class MailData: IMailData {
+    public MailHeader Header { get; set; }
+    public string Subject { get; set; } = "";
+    public MimeEntity? Body { get; set; } = null;
+
+    public MailData(MailHeader header, string subject) {
+        this.Header = header;
+        this.Subject = subject;
+    }
+
+    public MailData(MailHeader header, string subject, MimeEntity body) {
+        this.Header = header;
+        this.Subject = subject;
+        this.Body = body;
+    }
+
+    public MailData(MailHeader header, string subject, string body, BodyBuilder bodyBuilder) {
+        this.Header = header;
+        this.Subject = subject;
+        this.BodyToMimeEntity(bodyBuilder, body);
+    }
+
+
+    public MailData BodyToMimeEntity(BodyBuilder bodyBuilder, string body) {
+        bodyBuilder.TextBody = body;
+
+        this.Body = bodyBuilder.ToMessageBody();
+        return this;
+    }
+}

--- a/Core/Models/Mail/MailHeader.cs
+++ b/Core/Models/Mail/MailHeader.cs
@@ -2,7 +2,7 @@
 namespace GamesAPI.Core.Models;
 
 public class MailHeader {
-    public List<MailRecipientData> Recipients { get; set; } = new List<MailRecipientData>();
-    public List<MailRecipientData>? Ccs { get; set; } = new List<MailRecipientData>();
-    public List<MailRecipientData>? Bccs { get; set; } = new List<MailRecipientData>();
+    public List<MailRecipient> Recipients { get; set; } = new List<MailRecipient>();
+    public List<MailRecipient>? Ccs { get; set; } = new List<MailRecipient>();
+    public List<MailRecipient>? Bccs { get; set; } = new List<MailRecipient>();
 }

--- a/Core/Models/Mail/MailHeader.cs
+++ b/Core/Models/Mail/MailHeader.cs
@@ -1,0 +1,8 @@
+
+namespace GamesAPI.Core.Models;
+
+public class MailHeader {
+    public List<MailRecipientData> Recipients { get; set; } = new List<MailRecipientData>();
+    public List<MailRecipientData>? Ccs { get; set; } = new List<MailRecipientData>();
+    public List<MailRecipientData>? Bccs { get; set; } = new List<MailRecipientData>();
+}

--- a/Core/Models/Mail/MailRecipient.cs
+++ b/Core/Models/Mail/MailRecipient.cs
@@ -1,13 +1,13 @@
 namespace GamesAPI.Core.Models;
-public class MailRecipientData {
+public class MailRecipient {
     public string Address { get; set; }
     public string FullName { get; set; } = "";
 
-    public MailRecipientData(string address) {
+    public MailRecipient(string address) {
         this.Address = address;
     }
 
-    public MailRecipientData(string address, string fullName) {
+    public MailRecipient(string address, string fullName) {
         this.Address = address;
         this.FullName = fullName;
     }

--- a/Core/Models/Mail/MailRecipientData.cs
+++ b/Core/Models/Mail/MailRecipientData.cs
@@ -1,0 +1,14 @@
+namespace GamesAPI.Core.Models;
+public class MailRecipientData {
+    public string Address { get; set; }
+    public string FullName { get; set; } = "";
+
+    public MailRecipientData(string address) {
+        this.Address = address;
+    }
+
+    public MailRecipientData(string address, string fullName) {
+        this.Address = address;
+        this.FullName = fullName;
+    }
+}

--- a/Core/Models/Settings/MailSettings.cs
+++ b/Core/Models/Settings/MailSettings.cs
@@ -1,0 +1,10 @@
+namespace GamesAPI.Core.Models;
+
+public class MailSettings {
+    public required string Server { get; set; }
+    public int Port { get; set; }
+    public required string SenderName { get; set; }
+    public required string SenderEmail { get; set; }
+    public required string UserName { get; set; }
+    public required string Password { get; set; }
+}

--- a/Core/Services/Mail/IMailService.cs
+++ b/Core/Services/Mail/IMailService.cs
@@ -7,6 +7,7 @@ public interface IMailService {
     public void AddSender(MimeMessage emailMessage);
     public void AddRecipients(MimeMessage emailMessage, IMailData mailData);
     public void AddSubject(MimeMessage emailMessage, IMailData mailData);
-    public Task AddBody(MimeMessage emailMessage, IMailData mailData);
+    
+    public Task BuildBody(MimeMessage emailMessage, IMailData mailData);
     public Task<bool> Send(IMailData mailData);
 }

--- a/Core/Services/Mail/IMailService.cs
+++ b/Core/Services/Mail/IMailService.cs
@@ -1,0 +1,12 @@
+using GamesAPI.Core.Models;
+using MimeKit;
+
+namespace GamesAPI.Core.Services;
+
+public interface IMailService {
+    public void AddSender(MimeMessage emailMessage);
+    public void AddRecipients(MimeMessage emailMessage, IMailData mailData);
+    public void AddSubject(MimeMessage emailMessage, IMailData mailData);
+    public Task AddBody(MimeMessage emailMessage, IMailData mailData);
+    public Task<bool> Send(IMailData mailData);
+}

--- a/Core/Services/Mail/MailService.cs
+++ b/Core/Services/Mail/MailService.cs
@@ -18,12 +18,11 @@ public class MailService : IMailService {
         try {
             using (MimeMessage emailMessage = new MimeMessage()) {
                 this.AddSender(emailMessage);
-
                 this.AddRecipients(emailMessage, mailData);
-
                 this.AddSubject(emailMessage, mailData);
 
-                await this.AddBody(emailMessage, mailData);
+
+                await this.BuildBody(emailMessage, mailData);
                 
                 using (SmtpClient mailClient = new SmtpClient()) {
                     await mailClient.ConnectAsync(_mailSettings.Server, _mailSettings.Port, MailKit.Security.SecureSocketOptions.StartTls);
@@ -34,8 +33,8 @@ public class MailService : IMailService {
             }
             return true;
         }
-        catch (Exception) {
-            this._logger.LogError("Error sending mail {mailData}", mailData);
+        catch (Exception exception) {
+            this._logger.LogError($"Error sending mail {mailData}: {exception}");
             return false;
         }
     }
@@ -80,8 +79,9 @@ public class MailService : IMailService {
         emailMessage.Subject = mailData.Subject;
     }
 
-    public virtual Task AddBody(MimeMessage emailMessage, IMailData mailData) {
-        emailMessage.Body = mailData.Body;
+
+    public virtual Task BuildBody(MimeMessage emailMessage, IMailData mailData) {
+        emailMessage.Body = mailData.GetBody();
         return Task.CompletedTask;
     }
 }

--- a/Core/Services/Mail/MailService.cs
+++ b/Core/Services/Mail/MailService.cs
@@ -46,31 +46,31 @@ public class MailService : IMailService {
     }
 
     public void AddRecipients(MimeMessage emailMessage, IMailData mailData) {
-        foreach (MailRecipientData mailRecipientDataTo in mailData.Header.Recipients) {
-            if (mailRecipientDataTo.Address == "")
+        foreach (MailRecipient MailRecipientTo in mailData.Header.Recipients) {
+            if (MailRecipientTo.Address == "")
                 throw new ArgumentException("RecipientEmail address not provided.");
 
-            if (mailRecipientDataTo.FullName == "")
-                mailRecipientDataTo.FullName = mailRecipientDataTo.Address;
+            if (MailRecipientTo.FullName == "")
+                MailRecipientTo.FullName = MailRecipientTo.Address;
 
-            emailMessage.To.Add(new MailboxAddress(mailRecipientDataTo.FullName, mailRecipientDataTo.Address));
+            emailMessage.To.Add(new MailboxAddress(MailRecipientTo.FullName, MailRecipientTo.Address));
         }
 
         // cc and bcc
         if (mailData.Header.Ccs is not null) {
-            foreach (MailRecipientData mailRecipientDataCc in mailData.Header.Ccs) {
-                if (mailRecipientDataCc.Address == "")
+            foreach (MailRecipient MailRecipientCc in mailData.Header.Ccs) {
+                if (MailRecipientCc.Address == "")
                     throw new ArgumentException("Cc Email address not provided.");
 
-                emailMessage.Cc.Add(new MailboxAddress("Cc Receiver", mailRecipientDataCc.Address));
+                emailMessage.Cc.Add(new MailboxAddress("Cc Receiver", MailRecipientCc.Address));
             }
         }
         if (mailData.Header.Bccs is not null) {
-            foreach (MailRecipientData mailRecipientDataBcc in mailData.Header.Bccs) {
-                if (mailRecipientDataBcc.Address == "")
+            foreach (MailRecipient MailRecipientBcc in mailData.Header.Bccs) {
+                if (MailRecipientBcc.Address == "")
                     throw new ArgumentException("Bcc Email address not provided.");
 
-                emailMessage.Bcc.Add(new MailboxAddress("Bcc Receiver", mailRecipientDataBcc.Address));
+                emailMessage.Bcc.Add(new MailboxAddress("Bcc Receiver", MailRecipientBcc.Address));
             }
         }
     }

--- a/Core/Services/Mail/MailService.cs
+++ b/Core/Services/Mail/MailService.cs
@@ -1,0 +1,87 @@
+using GamesAPI.Core.Models;
+using MailKit.Net.Smtp;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace GamesAPI.Core.Services;
+
+public class MailService : IMailService {
+    private readonly MailSettings _mailSettings;
+    private readonly ILogger<MailService> _logger;
+
+    public MailService(IOptions<MailSettings> mailSettingsOptions, ILogger<MailService> logger) {
+        this._logger = logger;
+        this._mailSettings = mailSettingsOptions.Value;
+    }
+
+    public async Task<bool> Send(IMailData mailData) { 
+        try {
+            using (MimeMessage emailMessage = new MimeMessage()) {
+                this.AddSender(emailMessage);
+
+                this.AddRecipients(emailMessage, mailData);
+
+                this.AddSubject(emailMessage, mailData);
+
+                await this.AddBody(emailMessage, mailData);
+                
+                using (SmtpClient mailClient = new SmtpClient()) {
+                    await mailClient.ConnectAsync(_mailSettings.Server, _mailSettings.Port, MailKit.Security.SecureSocketOptions.StartTls);
+                    await mailClient.AuthenticateAsync(_mailSettings.UserName, _mailSettings.Password);
+                    await mailClient.SendAsync(emailMessage);
+                    await mailClient.DisconnectAsync(true);
+                }
+            }
+            return true;
+        }
+        catch (Exception) {
+            this._logger.LogError("Error sending mail {mailData}", mailData);
+            return false;
+        }
+    }
+
+    
+    public void AddSender(MimeMessage emailMessage) {
+        MailboxAddress emailFrom = new MailboxAddress(_mailSettings.SenderName, _mailSettings.SenderEmail);
+        emailMessage.From.Add(emailFrom);
+    }
+
+    public void AddRecipients(MimeMessage emailMessage, IMailData mailData) {
+        foreach (MailRecipientData mailRecipientDataTo in mailData.Header.Recipients) {
+            if (mailRecipientDataTo.Address == "")
+                throw new ArgumentException("RecipientEmail address not provided.");
+
+            if (mailRecipientDataTo.FullName == "")
+                mailRecipientDataTo.FullName = mailRecipientDataTo.Address;
+
+            emailMessage.To.Add(new MailboxAddress(mailRecipientDataTo.FullName, mailRecipientDataTo.Address));
+        }
+
+        // cc and bcc
+        if (mailData.Header.Ccs is not null) {
+            foreach (MailRecipientData mailRecipientDataCc in mailData.Header.Ccs) {
+                if (mailRecipientDataCc.Address == "")
+                    throw new ArgumentException("Cc Email address not provided.");
+
+                emailMessage.Cc.Add(new MailboxAddress("Cc Receiver", mailRecipientDataCc.Address));
+            }
+        }
+        if (mailData.Header.Bccs is not null) {
+            foreach (MailRecipientData mailRecipientDataBcc in mailData.Header.Bccs) {
+                if (mailRecipientDataBcc.Address == "")
+                    throw new ArgumentException("Bcc Email address not provided.");
+
+                emailMessage.Bcc.Add(new MailboxAddress("Bcc Receiver", mailRecipientDataBcc.Address));
+            }
+        }
+    }
+
+    public void AddSubject(MimeMessage emailMessage, IMailData mailData) {
+        emailMessage.Subject = mailData.Subject;
+    }
+
+    public virtual Task AddBody(MimeMessage emailMessage, IMailData mailData) {
+        emailMessage.Body = mailData.Body;
+        return Task.CompletedTask;
+    }
+}

--- a/Core/Templates/Mail/BaseMailTemplate.html
+++ b/Core/Templates/Mail/BaseMailTemplate.html
@@ -1,0 +1,10 @@
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Base mail template</title>
+</head>
+<body>
+    <h1>Base mail template!</h1>
+    <p>Param 1: {0}</p>
+    <p>Param 2: {1}</p>
+</body>

--- a/GamesAPI.csproj
+++ b/GamesAPI.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="ClosedXML" Version="0.102.2" />
+    <PackageReference Include="MailKit" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">

--- a/Models/Mail/TestHTMLMailData.cs
+++ b/Models/Mail/TestHTMLMailData.cs
@@ -1,12 +1,37 @@
+using System.Text;
+using GamesAPI.Models;
+
 namespace GamesAPI.Core.Models;
 
-public class TestHTMLMailData : HTMLMailData
-{
+public class TestHTMLMailData : HTMLMailData {
     public TestHTMLMailData(MailHeader header, string subject = "Test subject HTML", string mailPath = MailTemplates.TEST) : base(header, subject, mailPath) {
 
     }
-
+    
+    // Simple example of a manual loop implementation. 
+    // It is not recommended to use this in a production environment, gotta find a proper way to use Razor templates
     public override string processTemplateParams(string templateBody) {
-        return string.Format(templateBody, "testParam1");
+        var categoriesPlaceholder = "{categories}";
+
+        var categories = new List<Category>() { 
+            new Category() { Name = "Test category 1" }, 
+            new Category() { Name = "Test category 2" } 
+        };
+
+        int index = templateBody.IndexOf(categoriesPlaceholder);
+
+        if(index == -1)
+            return templateBody;
+
+        StringBuilder categoriesBuilder = new StringBuilder();
+
+        foreach(Category category in categories) {
+            categoriesBuilder.AppendLine($"<li>{category.Name}</li>");
+        }
+
+        // Insert the list of categories into the template body
+        templateBody = templateBody.Remove(index, categoriesPlaceholder.Length).Insert(index, categoriesBuilder.ToString());
+
+        return templateBody;
     }
 }

--- a/Models/Mail/TestHTMLMailData.cs
+++ b/Models/Mail/TestHTMLMailData.cs
@@ -9,7 +9,7 @@ public class TestHTMLMailData : HTMLMailData {
     }
     
     // Simple example of a manual loop implementation. 
-    // It is not recommended to use this in a production environment, gotta find a proper way to use Razor templates
+    // It is not recommended to use this in a production environment. Rendering Razor templates would be better
     public override string processTemplateParams(string templateBody) {
         var categoriesPlaceholder = "{categories}";
 

--- a/Models/Mail/TestHTMLMailData.cs
+++ b/Models/Mail/TestHTMLMailData.cs
@@ -1,0 +1,12 @@
+namespace GamesAPI.Core.Models;
+
+public class TestHTMLMailData : HTMLMailData
+{
+    public TestHTMLMailData(MailHeader header, string subject = "Test subject HTML", string mailPath = MailTemplates.TEST) : base(header, subject, mailPath) {
+
+    }
+
+    public override string processTemplateParams(string templateBody) {
+        return string.Format(templateBody, "testParam1");
+    }
+}

--- a/Models/Mail/TestHTMLMailData.cs
+++ b/Models/Mail/TestHTMLMailData.cs
@@ -30,7 +30,10 @@ public class TestHTMLMailData : HTMLMailData {
         }
 
         // Insert the list of categories into the template body
-        templateBody = templateBody.Remove(index, categoriesPlaceholder.Length).Insert(index, categoriesBuilder.ToString());
+        templateBody = templateBody
+            .Remove(index, categoriesPlaceholder.Length)
+            .Insert(index, categoriesBuilder.ToString())
+        ;
 
         return templateBody;
     }

--- a/Program.cs
+++ b/Program.cs
@@ -30,6 +30,8 @@ builder.Logging
 // Add services to the container.
 string? connectionString = builder.Configuration.GetConnectionString("BaseContext");
 
+builder.Services.Configure<MailSettings>(builder.Configuration.GetSection("MailSettings"));
+
 builder.Services.AddDbContext<BaseContext>(option => option.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
 
 builder.Services
@@ -71,6 +73,10 @@ builder.Services
 builder.Services
     .AddScoped<IUserService, UserService>()
     .AddScoped(typeof(IExcelExportService<>), typeof(ExcelExportService<>))
+;
+
+builder.Services
+    .AddScoped<IMailService, MailService>()
 ;
 
 builder.Services
@@ -120,7 +126,7 @@ builder.Services
 ;
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-//builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddEndpointsApiExplorer();
 
 builder.Services.AddSwaggerGen(option => {
     option.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme {

--- a/Templates/Mail/TestMailTemplate.html
+++ b/Templates/Mail/TestMailTemplate.html
@@ -6,5 +6,7 @@
 <body>
     <h1>Test mail HTML template</h1>
     <p>A list of categories for some reason</p>
-    {categories}
+    <ul>
+        {categories}
+    </ul>
 </body>

--- a/Templates/Mail/TestMailTemplate.html
+++ b/Templates/Mail/TestMailTemplate.html
@@ -1,0 +1,9 @@
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>TEST</title>
+</head>
+<body>
+    <h1>Test mail HTML template</h1>
+    <p>Param 1: {0}</p>
+</body>

--- a/Templates/Mail/TestMailTemplate.html
+++ b/Templates/Mail/TestMailTemplate.html
@@ -5,5 +5,6 @@
 </head>
 <body>
     <h1>Test mail HTML template</h1>
-    <p>Param 1: {0}</p>
+    <p>A list of categories for some reason</p>
+    {categories}
 </body>


### PR DESCRIPTION
Simplistic facade service for the MailKit library
- Simple class to compose the email (MailData)
- Send emails to N recipients (text, generic MimePart)
- Construct email bodies from a HTML template, with tokenization support
- Send emails with attachments

Example:
MailHeader header = new MailHeader {
    Recipients = new List<MailRecipient>() {
        new MailRecipient("test@test.com", "Test Emailed")
    },
    Ccs = new List<MailRecipient>(),
    Bccs = new List<MailRecipient>()
};

HTMLMailData mailData = new TestHTMLMailData(header);
mailData.AddAttachmentFromPath(Directory.GetCurrentDirectory() + "\\Controllers\\TestController.cs");

return await _mailService.Send(mailData);